### PR TITLE
Implement Masonry Layout using CSS Columns

### DIFF
--- a/src/components/article-card.js
+++ b/src/components/article-card.js
@@ -16,7 +16,7 @@ function ArticleCard({ node }) {
   );
 
   return (
-    <article key={node.fields.slug}>
+    <article className="inline-block mb-4" key={node.fields.slug}>
       <Link
         className={`text-current hover:text-gray-700 ${hoverEffect}`}
         to={node.fields.slug}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,14 +5,16 @@ import Layout from '../components/layout';
 import SEO from '../components/seo';
 import ArticleCard from '../components/article-card';
 
+import '../styles/index.css';
+
 const ArticleIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title;
   const posts = data.allMarkdownRemark.edges;
 
   return (
     <Layout location={location} title={siteTitle}>
-      <div className="mx-auto my-8 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-        <SEO title="All posts" />
+      <SEO title="All posts" />
+      <div className="mx-auto my-8 masonry">
         {posts.map(({ node }) => (
           <ArticleCard key={node.fields.slug} node={node} />
         ))}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,16 @@
+.masonry {
+  columns: 1;
+  column-gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .masonry {
+    columns: 2;
+  }
+}
+
+@media (min-width: 1280px) {
+  .masonry {
+    columns: 3;
+  }
+}


### PR DESCRIPTION
Article Cards previously weren't following the expected masonry layout when articles append below one another.

Since Tailwind CSS doesn't natively support `columns` CSS shorthand, custom CSS was used in place. This also means that custom breakpoints needed to be implemented, as you utilize Tailwind CSS's breakpoints using something like `xl:masonry`.

Fixes #3. 