### PR TITLE
Fix nullable images for Article Cards

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -81,3 +81,21 @@ exports.onCreateNode = async ({
     }
   }
 }
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type GhostPost implements Node {
+      cover_image: ParentImageSharp
+    }
+
+    type GhostAuthor implements Node {
+      image: ParentImageSharp
+    }
+
+    type ParentImageSharp {
+      childImageSharp: ImageSharp!
+    }
+  `
+  createTypes(typeDefs)
+}

--- a/src/components/article-card.js
+++ b/src/components/article-card.js
@@ -10,11 +10,15 @@ function ArticleCard({ node }) {
 
   const hoverEffect = "transition duration-300 ease-in-out no-underline";
 
-  const image = (
+  const coverImage = cover ? (
     <div className="bg-white">
       <Img className={`mb-4 hover:opacity-75 ${hoverEffect}`} fluid={cover.childImageSharp.fluid} />
     </div>
-  );  
+  ) : null  
+
+  const authorImage = author.image ? (
+    <Img className="h-4 rounded-full mr-2" fixed={author.image.childImageSharp.fixed} />
+  ) : null
 
   return (
     <article className="inline-block mb-4" key={node.slug}>
@@ -22,7 +26,7 @@ function ArticleCard({ node }) {
         className={`text-current hover:text-gray-700 ${hoverEffect}`}
         to={node.slug}
       >
-        { cover ? image : null }
+        { coverImage }
         <header>
           <h3 className="mb-2">
             {title}
@@ -37,7 +41,7 @@ function ArticleCard({ node }) {
             }}
           />
           <div className="flex items-center">
-            <Img className="h-4 rounded-full mr-2" fixed={author.image.childImageSharp.fixed} />
+            { authorImage }
             <small className="py-2">{author.name}</small>
           </div>
         </section>


### PR DESCRIPTION
Homepage is still displaying default Ghost posts possibly due to a bad GraphQL query after transitioning to Ghost CMS (#10).

Local build was failing due to a bad reference to a custom node defined in `gatsby-node.js`:
```
There was an error in your GraphQL query:

Cannot query field "cover_image" on type "GhostPost".
Cannot query field "image" on type "GhostAuthor".
```
Adds custom type definitions to nodes defined in `gatsby-node.js`, and enforces references in `index.js` to fallback to `null` if it doesn't exist.