### PR TITLE
Fix issue where cover images aren't displaying

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -86,15 +86,11 @@ exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = `
     type GhostPost implements Node {
-      cover_image: ParentImageSharp
+      cover_image: File
     }
 
     type GhostAuthor implements Node {
-      image: ParentImageSharp
-    }
-
-    type ParentImageSharp {
-      childImageSharp: ImageSharp!
+      image: File
     }
   `
   createTypes(typeDefs)


### PR DESCRIPTION
Homepage was previously loading old content due to a build fail (#10).

#12 was meant to fix the issue but it caused our GraphQL queries to fail because we were specifying a custom data type instead of the intended `File` node.