### PR TITLE
UI Tweaks

### DIFF
--- a/src/components/article-card.js
+++ b/src/components/article-card.js
@@ -21,7 +21,7 @@ function ArticleCard({ node }) {
   ) : null
 
   return (
-    <article className="inline-block mb-4" key={node.slug}>
+    <article className="break-inside-avoid mb-4" key={node.slug}>
       <Link
         className={`text-current hover:text-gray-700 ${hoverEffect}`}
         to={node.slug}

--- a/src/styles/ghost.css
+++ b/src/styles/ghost.css
@@ -11,6 +11,13 @@ figcaption {
   text-align: center;
 }
 
+/* Article Styles
+/* ---------------------------------------------------------- */
+
+article > section > p {
+  line-height: 1.75rem;
+}
+
 /* Koenig Styles
 /* ---------------------------------------------------------- */
 

--- a/src/styles/ghost.css
+++ b/src/styles/ghost.css
@@ -1,3 +1,16 @@
+img {
+  margin: 0
+}
+
+p {
+  text-align: justify;
+}
+
+figcaption {
+  font-size: .8375rem;
+  text-align: center;
+}
+
 /* Koenig Styles
 /* ---------------------------------------------------------- */
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,2 +1,8 @@
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .break-inside-avoid {
+    break-inside: avoid;
+  }
+}


### PR DESCRIPTION
Porting Ghost CMS HTML created some styling inconsistencies between the CMS and the website itself. 

This PR aims to fix some UI issues identified on our first two published articles including:
- Image captions had the same styling as paragraph text
<img width="568" alt="image" src="https://user-images.githubusercontent.com/7547794/95704846-30ac0a00-0c20-11eb-83d1-060a8c2e8050.png">

- Article cards were not spanning across columns when browsing on Google Chrome
<img width="1499" alt="image" src="https://user-images.githubusercontent.com/7547794/95705016-a617da80-0c20-11eb-88bf-cfb533dd396f.png">

- Spaces between lines in articles were too tightly spaced together
<img width="722" alt="image" src="https://user-images.githubusercontent.com/7547794/95705302-8208c900-0c21-11eb-8ce5-51400e57742c.png">

A follow-up PR will be addressed to make more significant adjustments to both the homepage and the article pages once we have a better direction of our branding and design.
