### PR TITLE
Implement Prismic Previews

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,7 @@
 // custom typefaces
+import * as React from 'react'
+import { PreviewStoreProvider } from 'gatsby-source-prismic'
+
 import 'prismjs/themes/prism.css';
 
 import './src/styles/tailwind.css';
@@ -25,3 +28,7 @@ var trustAllScripts = function () {
 export function onRouteUpdate() {
   trustAllScripts();
 };
+
+export const wrapRootElement = ({ element }) => (
+  <PreviewStoreProvider>{element}</PreviewStoreProvider>
+)

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,7 +47,7 @@ module.exports = {
     {
       resolve: `gatsby-source-prismic`,
       options: {
-        repositoryName: `outtaink`,
+        repositoryName: `${process.env.GATSBY_PRISMIC_REPOSITORY_NAME}`,
         accessToken: `${process.env.API_KEY}`,
         linkResolver: linkResolver,
         schemas: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,8 @@ require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })
 
+var linkResolver = require("./linkResolver");
+
 module.exports = {
   siteMetadata: {
     title: `OuttaInk`,
@@ -47,7 +49,7 @@ module.exports = {
       options: {
         repositoryName: `outtaink`,
         accessToken: `${process.env.API_KEY}`,
-        linkResolver: ({ node, key, value }) => post => `/${post.uid}`,
+        linkResolver: linkResolver,
         schemas: {
           article: require("./src/schemas/article.json"),
           author: require("./src/schemas/author.json"),

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,6 @@
+import * as React from 'react'
+import { PreviewStoreProvider } from 'gatsby-source-prismic'
+
+export const wrapRootElement = ({ element }) => (
+  <PreviewStoreProvider>{element}</PreviewStoreProvider>
+)

--- a/linkResolver.js
+++ b/linkResolver.js
@@ -1,0 +1,1 @@
+module.exports = ({ node, key, value }) => post => `/${post.uid}`;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import { graphql } from 'gatsby';
+import { withUnpublishedPreview } from 'gatsby-source-prismic';
+
+import ArticleTemplate from '../templates/article';
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
@@ -16,7 +19,12 @@ const NotFoundPage = ({ data, location }) => {
   );
 };
 
-export default NotFoundPage;
+// If an unpublished `page` document is previewed, PageTemplate will be rendered.
+export default withUnpublishedPreview(NotFoundPage, {
+  templateMap: {
+    article: ArticleTemplate,
+  },
+})
 
 export const pageQuery = graphql`
   query {

--- a/src/pages/preview.js
+++ b/src/pages/preview.js
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { withPreviewResolver } from 'gatsby-source-prismic'
+
+import { linkResolver } from '../../linkResolver'
+
+import Layout from '../components/layout'
+
+const PreviewPage = ({ isPreview, isLoading }) => {
+  if (isPreview === false) return 'Not a preview!'
+
+  return (
+    <Layout>
+      <p>Loading</p>
+    </Layout>
+  )
+}
+
+export default withPreviewResolver(PreviewPage, {
+  repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
+  linkResolver,
+})

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, graphql } from 'gatsby';
+import { withPreview } from 'gatsby-source-prismic'
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
@@ -49,7 +50,7 @@ const ArticleTemplate = ({ data, pageContext, location }) => {
   );
 };
 
-export default ArticleTemplate;
+export default withPreview(ArticleTemplate);
 
 export const pageQuery = graphql`
   query ArticleBySlug($url: String!) {


### PR DESCRIPTION
Adds support for Prismic Previews on our website. Followed the [guide](https://github.com/angeloashmore/gatsby-source-prismic/blob/494eee7812bf237ad89214e2852788a698895af0/docs/previews.md) on `gatsby-source-prismic`'s repo.

For more information on what Prismic Previews are and how they are created, visit Prismic's official support page on the topic: https://user-guides.prismic.io/en/articles/781294-how-to-set-up-a-preview

Since there isn't a good way to test this locally, the only thing I could do was to ensure that this implementation does not break any current functionality on our website.