### PR TITLE
Fix issue where Prismic Previews were not redirecting to Article

### DIFF
--- a/src/pages/preview.js
+++ b/src/pages/preview.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { withPreviewResolver } from 'gatsby-source-prismic'
 
-import { linkResolver } from '../../linkResolver'
+import linkResolver from '../../linkResolver'
 
 import Layout from '../components/layout'
 


### PR DESCRIPTION
In #18 we implemented the ability to preview Prismic Articles, but the redirecting logic wasn't working properly as the page stayed in the `Loading` state indefinitely:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/7547794/99155747-b5a79a80-2688-11eb-972a-037b00f70f8f.png">
This was due to an import bug made when passing `undefined` instead of `linkResolver` to `withPreviewResolver`, which means the resolver didn't know what the redirect logic was.