### PR TITLE
Add Hover State to Navigation Items

### DIFF
--- a/src/components/header/nav-items.js
+++ b/src/components/header/nav-items.js
@@ -19,7 +19,7 @@ export default function NavItems({ navItems, isMobile }) {
       }
       to={nav.src}
     >
-      <p>{nav.name}</p>
+      <p className="nav-name">{nav.name}</p>
       <p
         className={`text-default-50 mt-0.5 ${isMobile ? 'text-sm' : 'text-xs'}`}
       >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,10 +12,10 @@ figcaption {
   text-align: center;
 }
 
-/* Article Styles
-/* ---------------------------------------------------------- */
+a:link {
+  color: inherit;
+}
 
-article > section > p {
-  line-height: 1.75rem;
-  margin-bottom: 1.45rem;
+a:visited {
+  color: inherit;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,3 +2,36 @@ article > section > p {
   line-height: 1.75rem;
   margin-bottom: 1.45rem;
 }
+
+.nav-name {
+  position: relative;
+  background-image: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 50%,
+    rgba(255, 255, 255, 0) 50%
+  );
+  z-index: 1;
+}
+
+.nav-name::before {
+  position: absolute;
+  content: "";
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-image: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 50%,
+    #cce3e2 50%
+  );
+  z-index: -1;
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+  opacity: 0;
+}
+
+.nav-name:hover::before {
+  opacity: 1;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,8 +1,4 @@
-a:link {
-  color: inherit;
-  /* text-decoration: none; */
-}
-
-a:visited {
-  color: inherit;
+article > section > p {
+  line-height: 1.75rem;
+  margin-bottom: 1.45rem;
 }


### PR DESCRIPTION
Adds hover state to navigation items.

The change requires a hack that allows for transitions on `background-image` properties, or specifically `linear-gradient`.

Reference:
- https://medium.com/@dave_lunny/animating-css-gradients-using-only-css-d2fd7671e759
- https://keithjgrant.com/posts/2017/07/transitioning-gradients/