### PR TITLE
Enforce consistent punctuation

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -8,6 +8,8 @@ import Interviewee from '../components/interviewee';
 
 import Colon from '../../content/svg/colon.svg';
 
+import { sanitizeArticle } from '../utils/sanitize';
+
 const ArticleTemplate = ({ data, pageContext, location }) => {
   const article = data.prismicArticle.data;
   const siteTitle = data.site.siteMetadata.title;
@@ -17,6 +19,8 @@ const ArticleTemplate = ({ data, pageContext, location }) => {
   const [interviewee, headline] = title.split(/\s*[:：]\s*/);
 
   const { name, bio, links: { html: links } } = article;
+
+  const renderedHTML = sanitizeArticle(article.body.html);
 
   return (
     <Layout location={location} title={siteTitle}>
@@ -38,7 +42,7 @@ const ArticleTemplate = ({ data, pageContext, location }) => {
           </header>
           <section
             className="font-sans font-extralight tracking-wide"
-            dangerouslySetInnerHTML={{ __html: article.body.html }}
+            dangerouslySetInnerHTML={{ __html: renderedHTML }}
           />
           <hr className="mb-6" />
           <footer />

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -1,0 +1,15 @@
+const symbolReplacements = {
+  '“': '"',
+  '”': '"',
+};
+
+function sanitizeArticle(article) {
+  let buffer = article;
+  for (const before in symbolReplacements) {
+    const after = symbolReplacements[before];
+    buffer = buffer.replaceAll(before, after);
+  }
+  return buffer;
+}
+
+export { sanitizeArticle };


### PR DESCRIPTION
Writers can commonly mix punctuation between English and Chinese versions when writing their articles. This can affect readability of the articles as most Chinese punctuations are fixed-width and stretches the content as a result.

This PR uses a preliminary sanitization of articles by replacing certain Chinese punctuations with English ones instead. 

As a start, this is only enforced on quotation punctuations, but the implementation is designed to enforce other punctuations in the future as well, since it's essentially doing an iterative `replaceAll()` call. The performance impact of this is not evaluated at the moment.