### PR TITLE
Miscellaneous fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,15 +6,14 @@ var linkResolver = require('./linkResolver');
 
 module.exports = {
   siteMetadata: {
-    title: `OuttaInk`,
+    title: `Outtaink`,
     author: {
-      name: `Kyle Mathews`,
-      summary: `who lives and works in San Francisco building useful things.`,
+      name: `Jonathan Tseng`,
     },
-    description: `A starter blog demonstrating what Gatsby can do.`,
-    siteUrl: `https://gatsby-starter-blog-demo.netlify.app/`,
+    description: `A community for students to voice their experiences and lessons as they embrace the challenges of studying abroad.`,
+    siteUrl: `https://outtaink.com/`,
     social: {
-      twitter: `kylemathews`,
+      instagram: `outta.ink`,
     },
   },
   pathPrefix: '/outtaink.com',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,45 +35,6 @@ module.exports = {
         },
       },
     },
-    {
-      resolve: `gatsby-plugin-segment-js`,
-      options: {
-        // your segment write key for your production environment
-        // when process.env.NODE_ENV === 'production'
-        // required; non-empty string
-        prodKey: `r1BQEKQCHHZrEbPniJQhf6Q1B1Cc0QuF`,
-
-        // if you have a development env for your segment account, paste that key here
-        // when process.env.NODE_ENV === 'development'
-        // optional; non-empty string
-        devKey: `lPHDbhUfQSEgXF2Kje4AC91ECM2n8lgR`,
-
-        // boolean (defaults to false) on whether you want
-        // to include analytics.page() automatically
-        // if false, see below on how to track pageviews manually
-        trackPage: true,
-
-        // boolean (defaults to false); whether to delay load Segment
-        // ADVANCED FEATURE: only use if you leverage client-side routing (ie, Gatsby <Link>)
-        // This feature will force Segment to load _after_ either a page routing change
-        // or user scroll, whichever comes first. This delay time is controlled by
-        // `delayLoadTime` setting. This feature is used to help improve your website's
-        // TTI (for SEO, UX, etc).  See links below for more info.
-        // NOTE: But if you are using server-side routing and enable this feature,
-        // Segment will never load (because although client-side routing does not do
-        // a full page refresh, server-side routing does, thereby preventing Segment
-        // from ever loading).
-        // See here for more context:
-        // GIF: https://github.com/benjaminhoffman/gatsby-plugin-segment-js/pull/19#issuecomment-559569483
-        // TTI: https://github.com/GoogleChrome/lighthouse/blob/master/docs/scoring.md#performance
-        // Problem/solution: https://marketingexamples.com/seo/performance
-        delayLoad: true,
-
-        // number (default to 1000); time to wait after scroll or route change
-        // To be used when `delayLoad` is set to `true`
-        delayLoadTime: 1000,
-      },
-    },
     `gatsby-plugin-sitemap`,
     {
       resolve: 'gatsby-plugin-react-svg',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,9 +12,6 @@ module.exports = {
     },
     description: `A community for students to voice their experiences and lessons as they embrace the challenges of studying abroad.`,
     siteUrl: `https://outtaink.com/`,
-    social: {
-      instagram: `outta.ink`,
-    },
   },
   pathPrefix: '/outtaink.com',
   plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "gatsby-plugin-postcss": "^2.3.11",
         "gatsby-plugin-react-helmet": "^3.3.6",
         "gatsby-plugin-react-svg": "^3.0.0",
-        "gatsby-plugin-segment-js": "^3.5.0",
         "gatsby-plugin-sitemap": "^2.4.16",
         "gatsby-plugin-web-font-loader": "^1.0.4",
         "gatsby-source-filesystem": "^2.3.14",
@@ -9052,11 +9051,6 @@
       "dependencies": {
         "svg-react-loader": "^0.4.4"
       }
-    },
-    "node_modules/gatsby-plugin-segment-js": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-segment-js/-/gatsby-plugin-segment-js-3.5.0.tgz",
-      "integrity": "sha512-KrlULaEdj5KNUec6B12sSvirfXBYJvvAV08Wr2T9YC9LC3oczYhRhvImpzsJEuZyH343Lv2dsOK13I8Q0mWm2A=="
     },
     "node_modules/gatsby-plugin-sitemap": {
       "version": "2.4.16",
@@ -29290,11 +29284,6 @@
       "requires": {
         "svg-react-loader": "^0.4.4"
       }
-    },
-    "gatsby-plugin-segment-js": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-segment-js/-/gatsby-plugin-segment-js-3.5.0.tgz",
-      "integrity": "sha512-KrlULaEdj5KNUec6B12sSvirfXBYJvvAV08Wr2T9YC9LC3oczYhRhvImpzsJEuZyH343Lv2dsOK13I8Q0mWm2A=="
     },
     "gatsby-plugin-sitemap": {
       "version": "2.4.16",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "gatsby-plugin-postcss": "^2.3.11",
     "gatsby-plugin-react-helmet": "^3.3.6",
     "gatsby-plugin-react-svg": "^3.0.0",
-    "gatsby-plugin-segment-js": "^3.5.0",
     "gatsby-plugin-sitemap": "^2.4.16",
     "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-source-filesystem": "^2.3.14",

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -18,9 +18,6 @@ const SEO = ({ description, lang, meta, title }) => {
           siteMetadata {
             title
             description
-            social {
-              twitter
-            }
           }
         }
       }
@@ -52,23 +49,7 @@ const SEO = ({ description, lang, meta, title }) => {
         {
           property: `og:type`,
           content: `website`,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary`,
-        },
-        {
-          name: `twitter:creator`,
-          content: site.siteMetadata.social.twitter,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: metaDescription,
-        },
+        }
       ].concat(meta)}
     />
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,7 +18,7 @@ const ArticleIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <SEO title="All posts" />
+      <SEO title="Outtaink" />
       <Newsletter />
       <div className="my-8 mx-4 lg:mx-10 flex flex-col lg:flex-row">
         <div className="h-full lg:w-7/12 lg:mr-10">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,7 +18,7 @@ const ArticleIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <SEO title="Outtaink" />
+      <SEO title="Featured" />
       <Newsletter />
       <div className="my-8 mx-4 lg:mx-10 flex flex-col lg:flex-row">
         <div className="h-full lg:w-7/12 lg:mr-10">


### PR DESCRIPTION
Fixes some long-overdue fixes to the website that are too small to be written up as a separate task.
- Update site metadata to replace the default starter template
- Remove reliance on `Segment` as it's not being used anymore
- Fix SEO title to better match what the page titles
- Remove Twitter-related social tags