### PR TITLE
Add Fathom Analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,5 +49,11 @@ module.exports = {
         },
       },
     },
+    {
+      resolve: 'gatsby-plugin-fathom',
+      options: {
+        siteId: process.env.FATHOM_SITE_ID,
+      }
+    },
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource/noto-sans-tc": "^4.2.1",
         "gatsby": "^2.25.3",
         "gatsby-image": "^2.4.9",
+        "gatsby-plugin-fathom": "^2.1.0",
         "gatsby-plugin-feed": "^2.5.7",
         "gatsby-plugin-offline": "^3.2.13",
         "gatsby-plugin-postcss": "^2.3.11",
@@ -1264,9 +1265,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+      "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -8795,6 +8796,18 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/gatsby-plugin-fathom": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-fathom/-/gatsby-plugin-fathom-2.1.0.tgz",
+      "integrity": "sha512-zD6so5Z/Y+UM52kgelwC6hyNW8n9Xu3ApVrRKcENdljVvIkZmYYzfig3QIi5IVzEQtAsxLKihI6cjqp7+/z85g==",
+      "dependencies": {
+        "@babel/runtime": "7.12.13"
+      },
+      "peerDependencies": {
+        "gatsby": ">=2.0.0",
+        "react": ">=16.0.0"
       }
     },
     "node_modules/gatsby-plugin-feed": {
@@ -22548,9 +22561,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+      "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -29094,6 +29107,14 @@
             "is-number": "^7.0.0"
           }
         }
+      }
+    },
+    "gatsby-plugin-fathom": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-fathom/-/gatsby-plugin-fathom-2.1.0.tgz",
+      "integrity": "sha512-zD6so5Z/Y+UM52kgelwC6hyNW8n9Xu3ApVrRKcENdljVvIkZmYYzfig3QIi5IVzEQtAsxLKihI6cjqp7+/z85g==",
+      "requires": {
+        "@babel/runtime": "7.12.13"
       }
     },
     "gatsby-plugin-feed": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@fontsource/noto-sans-tc": "^4.2.1",
     "gatsby": "^2.25.3",
     "gatsby-image": "^2.4.9",
+    "gatsby-plugin-fathom": "^2.1.0",
     "gatsby-plugin-feed": "^2.5.7",
     "gatsby-plugin-offline": "^3.2.13",
     "gatsby-plugin-postcss": "^2.3.11",


### PR DESCRIPTION
Implements Fathom Analytics on the website. 

Fathom Analytics was selected over other alternatives (e.g. Google Analytics, Matomo, etc) because I was personally looking for a GDPR-compliant analytics platform that puts emphasis on privacy. Fathom Analytics also supports a cloud platform unlike Matomo that requires self-hosting for small teams, so Fathom was a perfect pick for its adoption (i.e. used by GitHub, Tailwindcss) and clean UI.