### PR TITLE
Modify Interviewee Bio Field to be Repeatable

### DIFF
--- a/src/components/interviewee.js
+++ b/src/components/interviewee.js
@@ -4,9 +4,13 @@ export default function Interviewee({ name, bio, links }) {
   return (
     <div className="mb-8 lg:h-screen sticky lg:top-12 lg:mt-32 lg:ml-12 lg:mb-12">
       <p className="font-zh mb-4 font-medium">{name}</p>
-      <p className="font-zh mb-4 text-sm font-light text-left leading-5 text-gray-600">
-        {bio}
-      </p>
+      {
+        bio.map(({text}) => (
+          <p className="font-zh mb-4 text-sm font-light text-left leading-5 text-gray-600">
+            {text}
+          </p>
+        ))
+      }
       <section
         className="font-zh text-sm font-light leading-6 interviewee-links"
         dangerouslySetInnerHTML={{ __html: links }}

--- a/src/schemas/article.json
+++ b/src/schemas/article.json
@@ -70,14 +70,14 @@
         "label": "Name"
       }
     },
-    "bio": {
-      "type": "Group",
-      "config": {
-        "fields": {
-          "text": {
-            "type": "Text",
-            "config": {
-              "label": "text"
+    "bio_group" : {
+      "type" : "Group",
+      "config" : {
+        "fields" : {
+          "text" : {
+            "type" : "Text",
+            "config" : {
+              "label" : "text"
             }
           }
         },

--- a/src/schemas/article.json
+++ b/src/schemas/article.json
@@ -3,7 +3,7 @@
     "title": {
       "type": "StructuredText",
       "config": {
-        "single": "heading1, heading2, heading3, heading4, heading5, heading6",
+        "single": "heading1,heading2,heading3,heading4,heading5,heading6",
         "label": "Title"
       }
     },
@@ -16,9 +16,11 @@
     "body": {
       "type": "StructuredText",
       "config": {
-        "multi": "paragraph, preformatted, heading1, heading2, heading3, heading4, heading5, heading6, strong, em, hyperlink, image, embed, list-item, o-list-item, rtl",
+        "multi": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl",
         "label": "Body",
-        "labels": ["caption"]
+        "labels": [
+          "caption"
+        ]
       }
     }
   },
@@ -33,7 +35,9 @@
       "type": "Link",
       "config": {
         "select": "document",
-        "customtypes": ["author"],
+        "customtypes": [
+          "author"
+        ],
         "label": "Author"
       }
     },
@@ -67,15 +71,23 @@
       }
     },
     "bio": {
-      "type": "Text",
+      "type": "Group",
       "config": {
+        "fields": {
+          "text": {
+            "type": "Text",
+            "config": {
+              "label": "text"
+            }
+          }
+        },
         "label": "Bio"
       }
     },
     "links": {
       "type": "StructuredText",
       "config": {
-        "multi": "paragraph, preformatted, strong, em, hyperlink, embed, list-item, o-list-item, rtl",
+        "multi": "paragraph,preformatted,strong,em,hyperlink,embed,list-item,o-list-item,rtl",
         "label": "Links"
       }
     }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -101,7 +101,9 @@ export const pageQuery = graphql`
           url
         }
         name
-        bio
+        bio {
+          text
+        }
         links {
           html
         }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -22,7 +22,7 @@ const ArticleTemplate = ({ data, pageContext, location }) => {
 
   const {
     name,
-    bio,
+    bio_group: bio,
     links: { html: links },
   } = article;
 
@@ -101,7 +101,7 @@ export const pageQuery = graphql`
           url
         }
         name
-        bio {
+        bio_group {
           text
         }
         links {


### PR DESCRIPTION
Modifies the `bio` field inside `Interviewee` to be repeatable. This corresponds to the right side of the article page where additional information about the interviewee is displayed. Rich text wasn't used here to preserve the styling of the component.

This change should cause no visual differences in most articles, but we have an upcoming article that requires an introduction for two people.