### PR TITLE
Split Title into separate Headline/Interviewee Fields

### DIFF
--- a/src/components/article-card.js
+++ b/src/components/article-card.js
@@ -9,12 +9,12 @@ import Colon from '../../content/svg/colon.svg';
 
 function ArticleCard({ node, imgClass, visible = true }) {
   const data = node.data;
-  const title = data.title.text;
   const cover = data.cover;
 
-  const hoverEffect = 'transition duration-300 ease-in-out no-underline';
+  const interviewee = data.name;
+  const headline = data.title.text;
 
-  const [interviewee, headline] = title.split(/\s*[:：]\s*/);
+  const hoverEffect = 'transition duration-300 ease-in-out no-underline';
 
   const renderedExcerpt = sanitizeArticle(node.data.excerpt);
 

--- a/src/components/featured/featured-card.js
+++ b/src/components/featured/featured-card.js
@@ -7,10 +7,10 @@ import { sanitizeArticle } from '../../utils/sanitize';
 
 export default function FeaturedCard({ node, index }) {
   const data = node.data;
-  const title = data.title.text;
   const cover = data.cover;
 
-  const [interviewee, headline] = title.split(/\s*[:：]\s*/);
+  const interviewee = data.name;
+  const headline = data.title.text;
 
   const renderedExcerpt = sanitizeArticle(node.data.excerpt);
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -64,6 +64,7 @@ export const pageQuery = graphql`
           data {
             excerpt
             date(formatString: "MMMM DD, YYYY")
+            name
             title {
               text
             }

--- a/src/schemas/article.json
+++ b/src/schemas/article.json
@@ -1,5 +1,11 @@
 {
   "Main": {
+    "name": {
+      "type": "Text",
+      "config": {
+        "label": "Name"
+      }
+    },
     "title": {
       "type": "StructuredText",
       "config": {
@@ -64,12 +70,6 @@
     }
   },
   "Interviewee": {
-    "name": {
-      "type": "Text",
-      "config": {
-        "label": "Name"
-      }
-    },
     "bio_group" : {
       "type" : "Group",
       "config" : {

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -17,8 +17,8 @@ const ArticleTemplate = ({ data, pageContext, location }) => {
   
   const coverUrl = article.cover.url;
 
-  const title = article.title.text;
-  const [interviewee, headline] = title.split(/\s*[:：]\s*/);
+  const interviewee = article.name;
+  const headline = article.title.text;
 
   const {
     name,


### PR DESCRIPTION
Avoid relying on writers to manually insert `:` by splitting the headline and interviewee fields apart.