### PR TITLE
Fix broken Prismic Previews

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,6 +32,13 @@ module.exports = {
         },
       },
     },
+    {
+      resolve: 'gatsby-plugin-prismic-previews',
+      options: {
+        repositoryName: `${process.env.GATSBY_PRISMIC_REPOSITORY_NAME}`,
+        accessToken: `${process.env.API_KEY}`,
+      },
+    },
     `gatsby-plugin-sitemap`,
     {
       resolve: 'gatsby-plugin-react-svg',

--- a/src/pages/preview.js
+++ b/src/pages/preview.js
@@ -3,9 +3,7 @@ import { withPrismicPreviewResolver } from 'gatsby-plugin-prismic-previews';
 
 import linkResolver from '../../linkResolver';
 
-const PreviewPage = ({ isPreview }) => {
-  if (isPreview === false) return 'Not a preview!';
-
+const PreviewPage = () => {
   return (
     <p>Loading</p>
   );

--- a/src/schemas/article.json
+++ b/src/schemas/article.json
@@ -60,24 +60,17 @@
       "config": {
         "label": "Excerpt"
       }
-    },
-    "interviewee": {
-      "type": "Link",
-      "config": {
-        "select": "document",
-        "label": "Interviewee"
-      }
     }
   },
   "Interviewee": {
-    "bio_group" : {
-      "type" : "Group",
-      "config" : {
-        "fields" : {
-          "text" : {
-            "type" : "Text",
-            "config" : {
-              "label" : "text"
+    "bio_group": {
+      "type": "Group",
+      "config": {
+        "fields": {
+          "text": {
+            "type": "Text",
+            "config": {
+              "label": "text"
             }
           }
         },
@@ -89,6 +82,21 @@
       "config": {
         "multi": "paragraph,preformatted,strong,em,hyperlink,embed,list-item,o-list-item,rtl",
         "label": "Links"
+      }
+    }
+  },
+  "Deprecated": {
+    "bio": {
+      "type": "Text",
+      "config": {
+        "label": "Bio"
+      }
+    },
+    "interviewee": {
+      "type": "Link",
+      "config": {
+        "select": "document",
+        "label": "Interviewee"
       }
     }
   }

--- a/src/schemas/author.json
+++ b/src/schemas/author.json
@@ -12,6 +12,18 @@
         "label": "Name"
       }
     },
+    "title": {
+      "type": "Text",
+      "config": {
+        "label": "Title"
+      }
+    },
+    "joined": {
+      "type": "Date",
+      "config": {
+        "label": "Joined"
+      }
+    },
     "image": {
       "type": "Image",
       "config": {

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { withPrismicPreviewResolver } from 'gatsby-plugin-prismic-previews'
+import { withPrismicPreview } from 'gatsby-plugin-prismic-previews'
 
 import SEO from '../components/seo';
 import Interviewee from '../components/interviewee';
@@ -62,7 +62,7 @@ const ArticleTemplate = ({ data }) => {
   );
 };
 
-export default withPrismicPreviewResolver(ArticleTemplate, [{
+export default withPrismicPreview(ArticleTemplate, [{
   repositoryName: process.env.GATSBY_PRISMIC_REPOSITORY_NAME,
   linkResolver,
 }]);


### PR DESCRIPTION
Prismic Previews broke following the Prismic 4 upgrade (#43).

Turns out I was forgetting to pass the new `gatsby-plugin-prismic-previews` to the `gatsby-config.js` file, along with other miscellaneous fixes.