### PR TITLE
Re-enable Prismic Previews on Next.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-transition-group": "^4.4.3",
         "classnames": "^2.3.1",
         "daisyui": "^1.14.2",
+        "js-cookie": "^3.0.1",
         "next": "^11.1.0",
         "prismic-dom": "^2.2.6",
         "prismic-reactjs": "^1.3.4",
@@ -5161,10 +5162,12 @@
       "integrity": "sha1-vEztbWxF/gdFKCuvyGqfjE/JzmE="
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6853,6 +6856,12 @@
         "react": "^16.8.0  || ^17.0.0",
         "react-dom": "^16.8.0  || ^17.0.0"
       }
+    },
+    "node_modules/react-use/node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "dev": true
     },
     "node_modules/react-use/node_modules/tslib": {
       "version": "2.3.1",
@@ -12472,10 +12481,9 @@
       "integrity": "sha1-vEztbWxF/gdFKCuvyGqfjE/JzmE="
     },
     "js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -13801,6 +13809,12 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "js-cookie": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+          "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+          "dev": true
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react-transition-group": "^4.4.3",
     "classnames": "^2.3.1",
     "daisyui": "^1.14.2",
+    "js-cookie": "^3.0.1",
     "next": "^11.1.0",
     "prismic-dom": "^2.2.6",
     "prismic-reactjs": "^1.3.4",

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -13,7 +13,7 @@ const Drawer: FC<DrawerProps> = ({ isOpen, setIsOpen }: DrawerProps) => {
   const closeDrawer = () => setIsOpen(false)
 
   return (
-    <MUIDrawer open={isOpen} onClose={closeDrawer} anchor="right">
+    <MUIDrawer open={isOpen} onClose={closeDrawer} anchor="left">
       <ul className="menu w-80 bg-white py-6">
         {navs.map(nav => (
           <li onClick={closeDrawer} key={nav.src}>

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+/**
+ * Site loader component
+ */
+ const Loader = () => (
+  <div className="loader">
+    <div className="ldsRipple"/>
+    <style jsx>{`
+      .loader {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        -moz-transform: translate(-50%, -50%);
+        -webkit-transform: translate(-50%, -50%);
+        -o-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+      }
+      .ldsRipple {
+        width: 64px;
+        height: 64px;
+      }
+      .ldsRipple:before, .ldsRipple:after {
+        content: '';
+        position: absolute;
+        border: 4px solid #333;
+        opacity: 1;
+        border-radius: 50%;
+        animation: lds-ripple 1s cubic-bezier(0, 0.2, 0.8, 1) infinite;
+      }
+      .ldsRipple:after {
+        animation-delay: -0.5s;
+      }
+      @keyframes lds-ripple {
+        0% {
+          top: 28px;
+          left: 28px;
+          width: 0;
+          height: 0;
+          opacity: 1;
+        }
+        100% {
+          top: -1px;
+          left: -1px;
+          width: 58px;
+          height: 58px;
+          opacity: 0;
+        }
+      }
+      `}</style>
+  </div>
+)
+
+export default Loader

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -20,13 +20,13 @@ const Navigation: FC<NavigationProps> = ({ setDrawerOpen }: NavigationProps) => 
   return (
     <div className="md:px-6">
       <div className="max-w-screen-page mx-6 md:mx-auto pt-6 md:py-10 flex items-center justify-between">
-        <SearchButton className="tooltip-right" />
+        <DrawerButton setDrawerOpen={setDrawerOpen} />
         <Link href="/">
           <a>
             <Logo />
           </a>
         </Link>
-        <DrawerButton setDrawerOpen={setDrawerOpen} />
+        <SearchButton className="tooltip-left" />
       </div>
     </div>
   )

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import Head from "next/head"
+
+export default function Custom404() {
+  return <>
+    <div>
+      <Head>
+          <title>404 - oops</title>
+      </Head>
+      <div className="fourohfour">
+        <h1>404 - Page Not Found</h1>
+        <Link href="/">
+          <a>
+            Go back home
+          </a>
+        </Link>
+      </div>
+      <style jsx>
+        {`
+          .fourohfour {
+            margin: 0 auto;
+            padding: 100px 0 100px 0;
+            max-width: 700px;
+          }
+        `}
+      </style>
+    </div>
+  </>
+}

--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -22,6 +22,10 @@ type ArticleProps = {
 }
 
 const Article = ({ article, author, previewRef }: ArticleProps) => {
+  if (!article || !article.id || !article.data) {
+    return <Custom404 />
+  }
+
   const {
     name,
     bio_group,
@@ -34,10 +38,6 @@ const Article = ({ article, author, previewRef }: ArticleProps) => {
   const router = useRouter()
   if (router.isFallback) {
     return <Loader />
-  }
-
-  if (!article.id) {
-    return <Custom404 />
   }
 
   useUpdatePreviewRef(previewRef, article.id)

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,25 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { repoName } from "../../prismicConfiguration";
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <script async defer src={`//static.cdn.prismic.io/prismic.js?repo=${repoName}&new=true`} />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/src/pages/api/exit-preview.tsx
+++ b/src/pages/api/exit-preview.tsx
@@ -1,0 +1,12 @@
+import url from 'url'
+
+export default async function exit(req, res) {
+  // Exit the current user from "Preview Mode". This function accepts no args.
+  res.clearPreviewData()
+
+  const queryObject = url.parse(req.url, true).query
+  const redirectUrl = queryObject && queryObject.currentUrl ? queryObject.currentUrl : '/'
+
+  res.writeHead(307, { Location: redirectUrl })
+  res.end()
+}

--- a/src/pages/api/preview.tsx
+++ b/src/pages/api/preview.tsx
@@ -1,0 +1,22 @@
+import { linkResolver } from '../../../prismicConfiguration'
+import { Client } from '../../utils/prismicHelpers'
+
+export default async (req, res) => {
+  const { token: ref, documentId } = req.query;
+  const redirectUrl = await Client(req)
+    .getPreviewResolver(ref, documentId)
+    .resolve(linkResolver, '/');
+
+  if (!redirectUrl) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  res.setPreviewData({ ref });
+
+  res.write(
+    `<!DOCTYPE html><html><head><meta http-equiv="Refresh" content="0; url=${redirectUrl}" />
+    <script>window.location.href = '${redirectUrl}'</script>
+    </head>`
+  );
+  res.end();
+};

--- a/src/utils/useUpdatePreviewRef.tsx
+++ b/src/utils/useUpdatePreviewRef.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import Cookies from 'js-cookie'
+import { repoName } from '../../prismicConfiguration'
+
+function getExitPreviewRoute(router) {
+  const defaultPreviewExitUrl = '/api/exit-preview'
+  const linkUrl = router.asPath ? `${defaultPreviewExitUrl}?currentUrl=${router.asPath}` : defaultPreviewExitUrl
+  return linkUrl
+}
+
+function timeout(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export default function useUpdatePreviewRef(previewRef, documentId) {
+  const router = useRouter()
+  const previewExitRoute = getExitPreviewRoute(router)
+  useEffect(() => {
+    const updatePreview = async () => {
+      await timeout(1000)
+
+      const rawPreviewCookie = Cookies.get('io.prismic.preview')
+      const previewCookie = rawPreviewCookie ? JSON.parse(rawPreviewCookie) : null
+
+      const previewCookieObject = previewCookie ? previewCookie[`${repoName}.prismic.io`] : null
+
+      const previewCookieRef = previewCookieObject && previewCookieObject.preview
+        ? previewCookieObject.preview
+        : null
+
+      if (router.isPreview) {
+        if (rawPreviewCookie && previewCookieRef) {
+          if (previewRef !== previewCookieRef) {
+            return router.push(`/api/preview?token=${previewCookieRef}&documentId=${documentId}`)
+          }
+        } else {
+          return router.push(previewExitRoute)
+        }
+      } else if (rawPreviewCookie && previewCookieRef) {
+        return router.push(`/api/preview?token=${previewCookieRef}&documentId=${documentId}`)
+      }
+      return undefined
+    }
+    updatePreview()
+  }, [])
+}


### PR DESCRIPTION
Re-enable Prismic Previews using the guide provided here: https://prismic.io/docs/technologies/previews-nextjs

Note that there are some code cleanups, but this is good enough as a first pass to unblock writers.